### PR TITLE
Use private submodule from orion-next/hugo-themes

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -36,10 +36,15 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      
       - name: Install Dart Sass Embedded
         run: sudo snap install dart-sass-embedded
-      - name: Checkout
-        uses: actions/checkout@v3
+      
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Checkout Hugo Theme Submodule
+        uses: actions/checkout@v4
         with:
           repository: orion-next/hugo-themes
           ref: themes/lithium
@@ -47,6 +52,7 @@ jobs:
           ssh-key: ${{ secrets.ORION_NEXT_HUGO_THEME_KEY }}
           persist-credentials: true
           submodules: recursive
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ssh-key: ${{ secrets.ORION_NEXT_HUGO_THEME_KEY }}
           submodules: recursive
       - name: Setup Pages
         id: pages

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -41,9 +41,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          repository: orion-next/hugo-themes
+          ref: themes/lithium
+          path: themes/lithium
           ssh-key: ${{ secrets.ORION_NEXT_HUGO_THEME_KEY }}
-          submodules: recursive
           persist-credentials: true
+          submodules: recursive
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.ORION_NEXT_HUGO_THEME_KEY }}
           submodules: recursive
+          persist-credentials: true
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "themes/lithium"]
 	path = themes/lithium
-	url = https://github.com/orion-next/lithium.git
+	url = https://github.com/orion-next/hugo-themes.git
+	branch = themes/lithium


### PR DESCRIPTION
GitHub workflow has been updated to allow for Lithium theme to be cloned from **orion-next/hugo-themes**.
- Deploy key created manually in **orion-next/hugo-themes**
- Repository secret created in current repo
- Workflow updated to
  - Use a separate job for cloning current repo
  - Use a separate job to then clone the private repo into specific folder
 
Normally this should work the same with submodules.   
But it's not, so the workflow is doing the submodule cloning "manually".